### PR TITLE
fix: correct sanitization provider factory invocation in purity tests

### DIFF
--- a/test/utils/purity-test.js
+++ b/test/utils/purity-test.js
@@ -101,7 +101,7 @@ describe('Purity Tests - Dependency Injection Verification', function() {
   describe('InputValidator with MockSanitizationProvider', function() {
     beforeEach(function() {
       // Reset to default provider after each test
-      InputValidator.configureSanitizationProvider(require('../../utils/sanitization-provider').default);
+      InputValidator.configureSanitizationProvider(require('../../utils/sanitization-provider').default());
     });
 
     it('should use injected sanitization provider', function() {


### PR DESCRIPTION
## 🐛 Bug Fix

This fixes a test failure that was introduced when PR #10 was merged. The test was incorrectly passing the factory function itself instead of calling it to get an instance.

### The Problem
```javascript
// Incorrect - passes the function itself
InputValidator.configureSanitizationProvider(require('../../utils/sanitization-provider').default);
```

### The Fix
```javascript
// Correct - calls the factory function to get an instance
InputValidator.configureSanitizationProvider(require('../../utils/sanitization-provider').default());
```

### Test Results
After this fix, all 9 purity tests pass successfully.

This should have been included in the original PR but was accidentally pushed to a wrong branch during review.